### PR TITLE
Fix StringView::get_data crash

### DIFF
--- a/omp-gdk/src/types/stringview.rs
+++ b/omp-gdk/src/types/stringview.rs
@@ -17,12 +17,8 @@ impl StringView {
     }
 
     pub fn get_data(&self) -> String {
-        unsafe {
-            std::ffi::CStr::from_ptr(self.data)
-                .to_str()
-                .unwrap()
-                .to_owned()
-        }
+        let cstr = unsafe { std::ffi::CStr::from_ptr(self.data) };
+        cstr.to_bytes().iter().map(|&c| c as char).collect()
     }
 }
 


### PR DESCRIPTION
When a player types any character from the extended ASCII codes (character code 128-255) into the chat (like `€` or `ÿ`), the server will crash with this stack backtrace:

```
thread '<unnamed>' panicked at ~/.cargo/git/checkouts/omprs-gdk-6d43e4105192f10e/8574490/omp-gdk/src/types/stringview.rs:23:18:
called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 0, error_len: Some(1) }
stack backtrace:
   0: rust_begin_unwind
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:75:14
   2: core::result::unwrap_failed
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/result.rs:1704:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/result.rs:1109:23
   4: omp_gdk::types::stringview::StringView::get_data
             at ~/.cargo/git/checkouts/omprs-gdk-6d43e4105192f10e/8574490/omp-gdk/src/types/stringview.rs:21:13
   5: OMPRS_OnPlayerText
             at ~/.cargo/git/checkouts/omprs-gdk-6d43e4105192f10e/8574490/omp-gdk/src/scripting/players/events.rs:235:13
```

This PR fixes the panic by interpreting the CStr bytes as UTF-8 chars. While most of the characters tested by me will also end up in the returned String, `€` won't. So this might need some further work but let's start by fixing the crash in first place.