### PR TITLE
Fix destroying vehicles

### DIFF
--- a/omp-gdk/src/scripting/actors/events.rs
+++ b/omp-gdk/src/scripting/actors/events.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::all)]
-use std::mem::transmute;
+use std::{mem::transmute, rc::Rc};
 
 use crate::{events::EventArgs, players::Player};
 
@@ -23,8 +23,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerGiveDamageActor(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_give_damage_actor(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_give_damage_actor(
             Player::new(*(*(*args).list).player),
             Actor::new(*(*(*args).list).actor),
             *(*(*args).list).amount,
@@ -47,8 +48,9 @@ pub unsafe extern "C" fn OMPRS_OnActorStreamIn(args: *const EventArgs<OnActorStr
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_actor_stream_in(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_actor_stream_in(
             Actor::new(*(*(*args).list).actor),
             Player::new(*(*(*args).list).forPlayer),
         );
@@ -68,8 +70,9 @@ pub unsafe extern "C" fn OMPRS_OnActorStreamOut(args: *const EventArgs<OnActorSt
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_actor_stream_out(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_actor_stream_out(
             Actor::new(*(*(*args).list).actor),
             Player::new(*(*(*args).list).forPlayer),
         );

--- a/omp-gdk/src/scripting/checkpoints/events.rs
+++ b/omp-gdk/src/scripting/checkpoints/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 #[repr(C)]
@@ -15,10 +17,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEnterCheckpoint(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_enter_checkpoint(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_enter_checkpoint(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -36,10 +37,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerLeaveCheckpoint(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_leave_checkpoint(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_leave_checkpoint(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -57,10 +57,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEnterRaceCheckpoint(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_enter_race_checkpoint(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_enter_race_checkpoint(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -78,9 +77,8 @@ pub unsafe extern "C" fn OMPRS_OnPlayerLeaveRaceCheckpoint(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_leave_race_checkpoint(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_leave_race_checkpoint(Player::new(*(*(*args).list).player));
     }
 }

--- a/omp-gdk/src/scripting/classes/events.rs
+++ b/omp-gdk/src/scripting/classes/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 #[repr(C)]
@@ -17,8 +19,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerRequestClass(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_request_class(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_request_class(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).classId,
         );

--- a/omp-gdk/src/scripting/core/events.rs
+++ b/omp-gdk/src/scripting/core/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, types::stringview::StringView};
 
 #[repr(C)]
@@ -13,8 +15,9 @@ pub unsafe extern "C" fn OMPRS_OnTick(args: *const EventArgs<OnTickArgs>) {
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_tick(*(*(*args).list).elapsed);
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_tick(*(*(*args).list).elapsed);
     }
 }
 
@@ -58,8 +61,9 @@ pub unsafe extern "C" fn OMPRS_OnRconLoginAttempt(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_rcon_login_attempt(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_rcon_login_attempt(
             (*(*(*args).list).address).get_data(),
             (*(*(*args).list).password).get_data(),
             *(*(*args).list).success,

--- a/omp-gdk/src/scripting/dialogs/events.rs
+++ b/omp-gdk/src/scripting/dialogs/events.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 use crate::{events::EventArgs, players::Player, types::stringview::StringView};
-use std::mem::transmute;
+use std::{mem::transmute, rc::Rc};
 
 #[repr(C)]
 pub struct OnDialogResponseArgs {
@@ -18,8 +18,9 @@ pub unsafe extern "C" fn OMPRS_OnDialogResponse(args: *const EventArgs<OnDialogR
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_dialog_response(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_dialog_response(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).dialogId,
             transmute(*(*(*args).list).response),

--- a/omp-gdk/src/scripting/gangzones/events.rs
+++ b/omp-gdk/src/scripting/gangzones/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 use super::GangZone;
@@ -18,8 +20,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEnterGangZone(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_enter_gang_zone(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_enter_gang_zone(
             Player::new(*(*(*args).list).player),
             GangZone::new(*(*(*args).list).zone),
         );
@@ -41,8 +44,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerLeaveGangZone(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_leave_gang_zone(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_leave_gang_zone(
             Player::new(*(*(*args).list).player),
             GangZone::new(*(*(*args).list).zone),
         );
@@ -64,8 +68,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerClickGangZone(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_click_gang_zone(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_click_gang_zone(
             Player::new(*(*(*args).list).player),
             GangZone::new(*(*(*args).list).zone),
         );

--- a/omp-gdk/src/scripting/menus/events.rs
+++ b/omp-gdk/src/scripting/menus/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 #[repr(C)]
@@ -16,8 +18,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerSelectedMenuRow(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_selected_menu_row(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_selected_menu_row(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).row,
         );
@@ -36,9 +39,8 @@ pub unsafe extern "C" fn OMPRS_OnPlayerExitedMenu(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_exited_menu(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_exited_menu(Player::new(*(*(*args).list).player));
     }
 }

--- a/omp-gdk/src/scripting/models/events.rs
+++ b/omp-gdk/src/scripting/models/events.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 use crate::{events::EventArgs, players::Player};
-use std::mem::transmute;
+use std::{mem::transmute, rc::Rc};
 
 #[repr(C)]
 pub struct OnPlayerFinishedDownloadingArgs {
@@ -17,10 +17,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerFinishedDownloading(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_finished_downloading(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_finished_downloading(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -40,8 +39,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerRequestDownload(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_request_download(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_request_download(
             Player::new(*(*(*args).list).player),
             transmute(*(*(*args).list).model_type),
             *(*(*args).list).checksum,

--- a/omp-gdk/src/scripting/objects/events.rs
+++ b/omp-gdk/src/scripting/objects/events.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::all)]
-use std::mem::transmute;
+use std::{mem::transmute, rc::Rc};
 
 use crate::{events::EventArgs, players::Player, types::vector::Vector3};
 
@@ -17,10 +17,9 @@ pub unsafe extern "C" fn OMPRS_OnObjectMove(args: *const EventArgs<OnObjectMoveA
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_object_moved(Object::new(*(*(*args).list).object));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_object_moved(Object::new(*(*(*args).list).object));
     }
 }
 
@@ -37,8 +36,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerObjectMove(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_object_moved(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_object_moved(
             Player::new(*(*(*args).list).player),
             PlayerObject::new(
                 *(*(*args).list).object,
@@ -68,8 +68,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEditObject(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_edit_object(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_edit_object(
             Player::new(*(*(*args).list).player),
             Object::new(*(*(*args).list).object),
             transmute(*(*(*args).list).response),
@@ -127,8 +128,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEditAttachedObject(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_edit_attached_object(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_edit_attached_object(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).index,
             *(*(*args).list).saved,
@@ -175,8 +177,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerSelectObject(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_select_object(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_select_object(
             Player::new(*(*(*args).list).player),
             Object::new(*(*(*args).list).object),
             *(*(*args).list).model,

--- a/omp-gdk/src/scripting/pickups/events.rs
+++ b/omp-gdk/src/scripting/pickups/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 use super::Pickup;
@@ -18,8 +20,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerPickUpPickup(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_pick_up_pickup(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_pick_up_pickup(
             Player::new(*(*(*args).list).player),
             Pickup::new(*(*(*args).list).pickup),
         );

--- a/omp-gdk/src/scripting/players/events.rs
+++ b/omp-gdk/src/scripting/players/events.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::all)]
 use std::mem::transmute;
+use std::rc::Rc;
 
 use super::Player;
 use crate::events::EventArgs;
@@ -20,10 +21,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerConnect(args: *const EventArgs<OnPlayerCo
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_connect(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_connect(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -39,10 +39,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerSpawn(args: *const EventArgs<OnPlayerSpaw
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_spawn(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_spawn(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -62,8 +61,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerCommandText(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_command_text(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_command_text(
             Player::new(*(*(*args).list).player),
             (*(*(*args).list).command).get_data(),
         );
@@ -91,8 +91,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerKeyStateChange(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_key_state_change(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_key_state_change(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).newKeys,
             *(*(*args).list).oldKeys,
@@ -116,8 +117,9 @@ pub unsafe extern "C" fn OMPRS_OnIncomingConnection(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_incoming_connection(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_incoming_connection(
             Player::new(*(*(*args).list).player),
             (*(*(*args).list).ipAddress).get_data(),
             *(*(*args).list).port,
@@ -138,8 +140,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerDisconnect(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_disconnect(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_disconnect(
             Player::new(*(*(*args).list).player),
             transmute(*(*(*args).list).reason),
         );
@@ -161,10 +164,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerRequestSpawn(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script
-            .borrow_mut()
-            .on_player_request_spawn(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_request_spawn(Player::new(*(*(*args).list).player));
         if crate::runtime::__terminate_event_chain {
             crate::runtime::__terminate_event_chain = false;
             return ret;
@@ -186,8 +188,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerStreamIn(args: *const EventArgs<OnPlayerS
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_stream_in(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_stream_in(
             Player::new(*(*(*args).list).player),
             Player::new(*(*(*args).list).forPlayer),
         );
@@ -207,8 +210,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerStreamOut(args: *const EventArgs<OnPlayer
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_stream_out(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_stream_out(
             Player::new(*(*(*args).list).player),
             Player::new(*(*(*args).list).forPlayer),
         );
@@ -229,8 +233,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerText(args: *const EventArgs<OnPlayerTextA
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_text(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_text(
             Player::new(*(*(*args).list).player),
             (*(*(*args).list).text).get_data(),
         );
@@ -261,8 +266,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerShotMissed(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_shot_missed(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_shot_missed(
             Player::new(*(*(*args).list).player),
             transmute(*(*(*args).list).weapon as u8),
             Vector3::new(*(*(*args).list).x, *(*(*args).list).y, *(*(*args).list).z),
@@ -295,8 +301,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerShotPlayer(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_shot_player(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_shot_player(
             Player::new(*(*(*args).list).player),
             Player::new(*(*(*args).list).target),
             transmute(*(*(*args).list).weapon as u8),
@@ -330,8 +337,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerShotVehicle(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_shot_vehicle(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_shot_vehicle(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).target),
             transmute(*(*(*args).list).weapon as u8),
@@ -365,8 +373,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerShotObject(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_shot_object(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_shot_object(
             Player::new(*(*(*args).list).player),
             Object::new(*(*(*args).list).target),
             transmute(*(*(*args).list).weapon as u8),
@@ -400,8 +409,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerShotPlayerObject(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_player_shot_player_object(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_shot_player_object(
             Player::new(*(*(*args).list).player),
             PlayerObject::new(
                 *(*(*args).list).target,
@@ -432,13 +442,14 @@ pub unsafe extern "C" fn OMPRS_OnPlayerDeath(args: *const EventArgs<OnPlayerDeat
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
+    for script in scripts.iter() {
         let killer = if (*(*(*args).list).killer).is_null() {
             None
         } else {
             Some(Player::new(*(*(*args).list).killer))
         };
-        script.borrow_mut().on_player_death(
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_death(
             Player::new(*(*(*args).list).player),
             killer,
             *(*(*args).list).reason,
@@ -462,13 +473,14 @@ pub unsafe extern "C" fn OMPRS_OnPlayerTakeDamage(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
+    for script in scripts.iter() {
         let from = if (*(*(*args).list).from).is_null() {
             None
         } else {
             Some(Player::new(*(*(*args).list).from))
         };
-        script.borrow_mut().on_player_take_damage(
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_take_damage(
             Player::new(*(*(*args).list).player),
             from,
             *(*(*args).list).amount,
@@ -494,8 +506,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerGiveDamage(args: *const EventArgs<OnPlaye
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_give_damage(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_give_damage(
             Player::new(*(*(*args).list).player),
             Player::new(*(*(*args).list).to),
             *(*(*args).list).amount,
@@ -521,8 +534,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerInteriorChange(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_interior_change(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_interior_change(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).newInterior,
             *(*(*args).list).oldInterior,
@@ -546,8 +560,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerStateChange(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_state_change(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_state_change(
             Player::new(*(*(*args).list).player),
             transmute(*(*(*args).list).newState),
             transmute(*(*(*args).list).oldState),
@@ -570,8 +585,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerClickMap(args: *const EventArgs<OnPlayerC
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_click_map(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_click_map(
             Player::new(*(*(*args).list).player),
             Vector3::new(*(*(*args).list).x, *(*(*args).list).y, *(*(*args).list).z),
         );
@@ -594,8 +610,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerClickPlayer(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_click_player(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_click_player(
             Player::new(*(*(*args).list).player),
             Player::new(*(*(*args).list).clicked),
             transmute(*(*(*args).list).source),
@@ -620,8 +637,9 @@ pub unsafe extern "C" fn OMPRS_OnClientCheckResponse(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_client_check_response(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_client_check_response(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).actionType,
             *(*(*args).list).address,
@@ -643,10 +661,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerUpdate(args: *const EventArgs<OnPlayerUpd
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script
-            .borrow_mut()
-            .on_player_update(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_player_update(Player::new(*(*(*args).list).player));
         if crate::runtime::__terminate_event_chain {
             crate::runtime::__terminate_event_chain = false;
             return ret;

--- a/omp-gdk/src/scripting/textdraws/events.rs
+++ b/omp-gdk/src/scripting/textdraws/events.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+use std::rc::Rc;
+
 use crate::{events::EventArgs, players::Player};
 
 use super::{PlayerTextDraw, TextDraw};
@@ -17,10 +19,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerCancelTextDrawSelection(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_cancel_text_draw_selection(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_cancel_text_draw_selection(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -38,10 +39,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerCancelPlayerTextDrawSelection(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_player_cancel_player_text_draw_selection(Player::new(*(*(*args).list).player));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_cancel_player_text_draw_selection(Player::new(*(*(*args).list).player));
     }
 }
 
@@ -60,8 +60,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerClickTextDraw(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_click_text_draw(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_click_text_draw(
             Player::new(*(*(*args).list).player),
             TextDraw::new(*(*(*args).list).textdraw),
         );
@@ -83,8 +84,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerClickPlayerTextDraw(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_click_player_text_draw(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_click_player_text_draw(
             Player::new(*(*(*args).list).player),
             PlayerTextDraw::new(
                 *(*(*args).list).textdraw,

--- a/omp-gdk/src/scripting/vehicles/events.rs
+++ b/omp-gdk/src/scripting/vehicles/events.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::all)]
-use std::mem::transmute;
+use std::{mem::transmute, rc::Rc};
 
 use crate::{events::EventArgs, players::Player, types::vector::Vector3};
 
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleStreamOut(args: *const EventArgs<OnVehic
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_vehicle_stream_out(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_vehicle_stream_out(
             Vehicle::new(*(*(*args).list).vehicle),
             Player::new(*(*(*args).list).player),
         );

--- a/omp-gdk/src/scripting/vehicles/events.rs
+++ b/omp-gdk/src/scripting/vehicles/events.rs
@@ -18,8 +18,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleStreamIn(args: *const EventArgs<OnVehicl
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_vehicle_stream_in(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_vehicle_stream_in(
             Vehicle::new(*(*(*args).list).vehicle),
             Player::new(*(*(*args).list).player),
         );
@@ -61,8 +62,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleDeath(args: *const EventArgs<OnVehicleDe
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_vehicle_death(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_vehicle_death(
             Vehicle::new(*(*(*args).list).vehicle),
             Player::new(*(*(*args).list).player),
         );
@@ -85,8 +87,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerEnterVehicle(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_enter_vehicle(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_enter_vehicle(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
             *(*(*args).list).passenger,
@@ -109,8 +112,9 @@ pub unsafe extern "C" fn OMPRS_OnPlayerExitVehicle(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_player_exit_vehicle(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_player_exit_vehicle(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
         );
@@ -132,8 +136,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleDamageStatusUpdate(
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_vehicle_damage_status_update(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_vehicle_damage_status_update(
             Vehicle::new(*(*(*args).list).vehicle),
             Player::new(*(*(*args).list).player),
         );
@@ -157,8 +162,9 @@ pub unsafe extern "C" fn OMPRS_OnVehiclePaintJob(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_vehicle_paint_job(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_vehicle_paint_job(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
             *(*(*args).list).paintJob,
@@ -186,8 +192,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleMod(args: *const EventArgs<OnVehicleModA
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_vehicle_mod(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_vehicle_mod(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
             *(*(*args).list).component,
@@ -218,8 +225,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleRespray(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_vehicle_respray(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_vehicle_respray(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
             *(*(*args).list).color1,
@@ -247,8 +255,9 @@ pub unsafe extern "C" fn OMPRS_OnEnterExitModShop(args: *const EventArgs<OnEnter
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script.borrow_mut().on_enter_exit_mod_shop(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_enter_exit_mod_shop(
             Player::new(*(*(*args).list).player),
             *(*(*args).list).enterexit != 0,
             *(*(*args).list).interiorId,
@@ -268,10 +277,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleSpawn(args: *const EventArgs<OnVehicleSp
         .unwrap()
         .as_mut()
         .unwrap();
-    for script in scripts.iter_mut() {
-        script
-            .borrow_mut()
-            .on_vehicle_spawn(Vehicle::new(*(*(*args).list).vehicle));
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        script.on_vehicle_spawn(Vehicle::new(*(*(*args).list).vehicle));
     }
 }
 
@@ -298,8 +306,9 @@ pub unsafe extern "C" fn OMPRS_OnUnoccupiedVehicleUpdate(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_unoccupied_vehicle_update(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_unoccupied_vehicle_update(
             Vehicle::new(*(*(*args).list).vehicle),
             Player::new(*(*(*args).list).player),
             UnoccupiedVehicleUpdate {
@@ -340,8 +349,9 @@ pub unsafe extern "C" fn OMPRS_OnTrailerUpdate(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_trailer_update(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_trailer_update(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).trailer),
         );
@@ -370,8 +380,9 @@ pub unsafe extern "C" fn OMPRS_OnVehicleSirenStateChange(
         .as_mut()
         .unwrap();
     let mut ret = false;
-    for script in scripts.iter_mut() {
-        ret = script.borrow_mut().on_vehicle_siren_state_change(
+    for script in scripts.iter() {
+        let script = &mut *(*Rc::as_ptr(script)).as_ptr();
+        ret = script.on_vehicle_siren_state_change(
             Player::new(*(*(*args).list).player),
             Vehicle::new(*(*(*args).list).vehicle),
             *(*(*args).list).sirenState,


### PR DESCRIPTION
Fix runtime panic below by bypassing the borrow checker.

```
thread '<unnamed>' panicked at ~/Projects/rust/omprs-gdk/omp-gdk/src/scripting/vehicles/events.rs:43:16:
already borrowed: BorrowMutError
```

You can easily reproduce it by implementing this:

```
    fn on_player_command_text(&mut self, player: Player, message: String) -> bool {
        if &message == "/spawn" {
            let vehicle = Vehicle::create(411, player.get_pos(), 0.0, -1, -1, -1, false).unwrap();
            player.send_client_message(
                Colour::from_rgba(0xFFFFFFFF),
                &format!("spawned vehicle with id {}", vehicle.get_id()),
            );
            return true;
        }
        if message.starts_with("/destroy ") {
            let id: i32 = message.split_whitespace().nth(1).unwrap().parse().unwrap();
            let vehicle = omp::vehicles::Vehicle::get_from_id(id).unwrap();
            player.send_client_message(
                Colour::from_rgba(0xFFFFFFFF),
                &format!("deleting vehicle with id {id}"),
            );
            vehicle.destroy();
            return true;
        }
        false
    }
```

Just make sure that the client actually streams in the vehicle before destroying it.